### PR TITLE
Ignore the border lines on `iz`

### DIFF
--- a/autoload/textobj/fold.vim
+++ b/autoload/textobj/fold.vim
@@ -39,12 +39,20 @@ endfunction
 function! textobj#fold#select_i()
   call s:move_to_the_start_point()
   let start_pos = getpos('.')
+  if &foldmethod ==# 'marker'
+    " Next line
+    let start_pos[1] += 1
+  endif
   for i in range(v:count1 - 1)
     call s:move_to_the_end_point('i', 0)
     normal! j
   endfor
   call s:move_to_the_end_point('i', 0)
   let end_pos = getpos('.')
+  if &foldmethod ==# 'marker'
+    " Previous line
+    let end_pos[1] -= 1
+  endif
 
   return ['V', start_pos, end_pos]
 endfunction

--- a/doc/textobj-fold.txt
+++ b/doc/textobj-fold.txt
@@ -72,6 +72,9 @@ KEY MAPPINGS					*textobj-fold-key-mappings*
 	Leading or trailing lines which are not in any foldings are also
 	counted too.
 
+	If the current |foldmethod| is "foldmarker", ignore the lines that
+	contain the marker.
+
 	Note that this object is linewise.  In Visual mode, the current
 	selection will be switched to linewise.  In Operator-pending mode,
 	affected text will be linewise.
@@ -104,9 +107,6 @@ BUGS						*textobj-fold-bugs*
 
 - Even if user explicitly specify a wise for an operator by |o_v| or others,
   |<Plug>(textobj-fold-a)| and |<Plug>(textobj-fold-i)| are always linewise.
-
-- |<Plug>(textobj-fold-a)| is not perfectly implemented.  Currently, it
-  behaves as same as |<Plug>(textobj-fold-i)|.
 
 - In Visual-mode, the current selection is overriden by new selection.
 


### PR DESCRIPTION
This will ignore the first and last fold lines on `iz` motion.

Only useful on `foldmethod=marker`, so ignore this on other methods.